### PR TITLE
Generate RPMs

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -47,6 +47,8 @@ tracks:
     - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc}
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc}
     devel_branch: null
     last_version: 0.7.0
     name: bfl
@@ -63,6 +65,8 @@ tracks:
     - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc}
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc}
     devel_branch: null
     last_version: 0.7.0
     name: bfl


### PR DESCRIPTION
Looks like you're doing some Bloom voodoo-magic in your `tracks.yml`, so you didn't get RPM generation actions added like everyone else in Indigo and Jade.

Could you please add them and run the RPM generator for Indigo and Jade? I have already tried it in a fork, and `bfl` seems to work just fine on Fedora.

``` bash
git clone https://github.com/ros-gbp/bfl-release
cd bfl-release
git-bloom-generate -y rosrpm --prefix release/indigo indigo -i 6
git-bloom-generate -y rosrpm --prefix release/jade jade -i 2
git push --all && git push --tags
```

Thanks,

--scott
